### PR TITLE
added mol print functionally for Clang compiler

### DIFF
--- a/include/boost/mpl/print.hpp
+++ b/include/boost/mpl/print.hpp
@@ -37,8 +37,7 @@ namespace aux {
       static const unsigned value = 1;
   };
 #endif
-} // namespace aux 
-
+} // namespace aux
 
 template <class T>
 struct print
@@ -47,7 +46,9 @@ struct print
     , aux::print_base
 #endif 
 {
-#if defined(BOOST_MSVC)
+#if defined(__clang__)
+    const int m_x = 1 / (sizeof(T) - sizeof(T));
+#elif defined(BOOST_MSVC)
     enum { n = sizeof(T) + -1 };
 #elif defined(__MWERKS__)
     void f(int);


### PR DESCRIPTION
Please include this in MPL.  I've only made the change on this develop branch.

This change enables mol::print for the Clang compiler.

Please advise me when this has been added.

Robert Ramey
