### PR TITLE
Constexpr support for integral_wrapper

### DIFF
--- a/include/boost/mpl/aux_/integral_wrapper.hpp
+++ b/include/boost/mpl/aux_/integral_wrapper.hpp
@@ -77,7 +77,7 @@ struct AUX_WRAPPER_NAME
     // functions that return objects of both arithmetic ('int', 'long',
     // 'double', etc.) and wrapped integral types (for an example, see 
     // "mpl/example/power.cpp")
-    operator AUX_WRAPPER_VALUE_TYPE() const { return static_cast<AUX_WRAPPER_VALUE_TYPE>(this->value); } 
+    BOOST_CONSTEXPR operator AUX_WRAPPER_VALUE_TYPE() const { return static_cast<AUX_WRAPPER_VALUE_TYPE>(this->value); } 
 };
 
 #if !defined(BOOST_NO_INCLASS_MEMBER_INITIALIZATION)


### PR DESCRIPTION
Allows accessing integral_wrapper values within constexpr functions.
