### PR TITLE
eliminate unnecessary workaround for modern msvc versions

### DIFF
--- a/include/boost/mpl/has_xxx.hpp
+++ b/include/boost/mpl/has_xxx.hpp
@@ -155,10 +155,10 @@ template<> struct trait<T> \
 // SFINAE-based implementations below are derived from a USENET newsgroup's 
 // posting by Rani Sharoni (comp.lang.c++.moderated, 2002-03-17 07:45:09 PST)
 
-#   elif BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1400)) \
+#   elif BOOST_WORKAROUND(BOOST_MSVC, <= 1400) \
       || BOOST_WORKAROUND(__IBMCPP__, <= 700)
 
-// MSVC 7.1+ & VACPP
+// MSVC 7.1 & MSVC 8.0 & VACPP
 
 // agurt, 15/jun/05: replace overload-based SFINAE implementation with SFINAE
 // applied to partial specialization to fix some apparently random failures 


### PR DESCRIPTION
There is a very old workaround for MSVC in has_xxx.hpp that is no longer needed. It is now causing problems for Boost.Range (see https://github.com/boostorg/range/pull/11 for a full discussion of the problem).

I did some digging into the reason for the workaround, and believe it is in response to the following ancient bug: [#1317](https://svn.boost.org/trac/boost/ticket/1317). I can confirm that the test case in that bug report indeed fails without the workaround on msvc 8. However, in more recent versions, the workaround is unnecessary.

I have run mpl's full regression test suite with msvc 8, 9, 10, 11, and 12. No regressions. I have also tested the code in bug #1317 with the same compiler versions without any trouble.
