### PR TITLE
add back the has_xxx workaround for msvc if used with nvcc

### DIFF
--- a/include/boost/mpl/has_xxx.hpp
+++ b/include/boost/mpl/has_xxx.hpp
@@ -156,6 +156,7 @@ template<> struct trait<T> \
 // posting by Rani Sharoni (comp.lang.c++.moderated, 2002-03-17 07:45:09 PST)
 
 #   elif BOOST_WORKAROUND(BOOST_MSVC, <= 1400) \
+      || (BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1800)) && defined(__CUDACC__)) \
       || BOOST_WORKAROUND(__IBMCPP__, <= 700)
 
 // MSVC 7.1 & MSVC 8.0 & VACPP


### PR DESCRIPTION
In boostorg/mpl#8 I scoped a workaround to the affected versions of msvc. It turns out that breaks CUDA builds with nvcc. This fine-tunes the workaround for that case. I would dearly love this to be in the upcoming release.
