### PR TITLE
Fix to Ticket #11001

### DIFF
--- a/include/boost/mpl/aux_/insert_range_impl.hpp
+++ b/include/boost/mpl/aux_/insert_range_impl.hpp
@@ -44,7 +44,7 @@ struct insert_range_impl
         >
     struct apply
 #if !defined(BOOST_MPL_CFG_NO_NESTED_FORWARDING)
-        : fold<
+        : reverse_fold<
               joint_view<
                   iterator_range<typename begin<Sequence>::type,Pos>
                 , joint_view<
@@ -53,12 +53,12 @@ struct insert_range_impl
                     >
                 >
             , typename clear<Sequence>::type
-            , insert<_1, end<_1>, _2>
+            , insert<_1, begin<_1>, _2>
             >
     {
 #else
     {
-        typedef typename fold<
+        typedef typename reverse_fold<
                 joint_view<
                     iterator_range<typename begin<Sequence>::type,Pos>
                   , joint_view<
@@ -67,7 +67,7 @@ struct insert_range_impl
                       >
                   >
               , typename clear<Sequence>::type
-              , insert<_1, end<_1>, _2>
+              , insert<_1, begin<_1>, _2>
               >::type type;
 #endif
     };

--- a/include/boost/mpl/aux_/insert_range_impl.hpp
+++ b/include/boost/mpl/aux_/insert_range_impl.hpp
@@ -14,9 +14,10 @@
 // $Date$
 // $Revision$
 
-#include <boost/mpl/copy.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/fold.hpp>
+#include <boost/mpl/insert.hpp>
 #include <boost/mpl/clear.hpp>
-#include <boost/mpl/front_inserter.hpp>
 #include <boost/mpl/joint_view.hpp>
 #include <boost/mpl/iterator_range.hpp>
 #include <boost/mpl/aux_/na_spec.hpp>
@@ -43,29 +44,31 @@ struct insert_range_impl
         >
     struct apply
 #if !defined(BOOST_MPL_CFG_NO_NESTED_FORWARDING)
-        : reverse_copy<
-              joint_view< 
+        : fold<
+              joint_view<
                   iterator_range<typename begin<Sequence>::type,Pos>
-                , joint_view< 
+                , joint_view<
                       Range
                     , iterator_range<Pos,typename end<Sequence>::type>
                     >
                 >
-            , front_inserter< typename clear<Sequence>::type >
+            , typename clear<Sequence>::type
+            , insert<_1, end<_1>, _2>
             >
     {
 #else
     {
-        typedef typename reverse_copy<
-              joint_view< 
-                  iterator_range<typename begin<Sequence>::type,Pos>
-                , joint_view< 
-                      Range
-                    , iterator_range<Pos,typename end<Sequence>::type>
-                    >
-                >
-            , front_inserter< typename clear<Sequence>::type >
-            >::type type;
+        typedef typename fold<
+                joint_view<
+                    iterator_range<typename begin<Sequence>::type,Pos>
+                  , joint_view<
+                        Range
+                      , iterator_range<Pos,typename end<Sequence>::type>
+                      >
+                  >
+              , typename clear<Sequence>::type
+              , insert<_1, end<_1>, _2>
+              >::type type;
 #endif
     };
 };

--- a/include/boost/mpl/map/aux_/insert_range_impl.hpp
+++ b/include/boost/mpl/map/aux_/insert_range_impl.hpp
@@ -1,0 +1,41 @@
+
+#ifndef BOOST_MPL_MAP_AUX_INSERT_RANGE_IMPL_HPP_INCLUDED
+#define BOOST_MPL_MAP_AUX_INSERT_RANGE_IMPL_HPP_INCLUDED
+
+// Copyright Bruno Dutra 2015
+//
+// Distributed under the Boost Software License, Version 1.0. 
+// (See accompanying file LICENSE_1_0.txt or copy at 
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/mpl for documentation.
+
+// $Id$
+// $Date$
+// $Revision$
+
+#include <boost/mpl/insert_range_fwd.hpp>
+#include <boost/mpl/map/aux_/tag.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/fold.hpp>
+#include <boost/mpl/insert.hpp>
+
+namespace boost { namespace mpl {
+
+template<>
+struct insert_range_impl< aux::map_tag >
+{
+    template<
+          typename Sequence
+        , typename /*Pos*/
+        , typename Range
+        >
+    struct apply
+        : fold<Range, Sequence, insert<_1, _2> >
+    {
+    };
+};
+
+}}
+
+#endif // BOOST_MPL_MAP_AUX_INSERT_RANGE_IMPL_HPP_INCLUDED

--- a/include/boost/mpl/map/map0.hpp
+++ b/include/boost/mpl/map/map0.hpp
@@ -19,6 +19,7 @@
 #include <boost/mpl/map/aux_/at_impl.hpp>
 //#include <boost/mpl/map/aux_/O1_size.hpp>
 #include <boost/mpl/map/aux_/insert_impl.hpp>
+#include <boost/mpl/map/aux_/insert_range_impl.hpp>
 #include <boost/mpl/map/aux_/erase_impl.hpp>
 #include <boost/mpl/map/aux_/erase_key_impl.hpp>
 #include <boost/mpl/map/aux_/has_key_impl.hpp>

--- a/include/boost/mpl/set/aux_/insert_range_impl.hpp
+++ b/include/boost/mpl/set/aux_/insert_range_impl.hpp
@@ -1,0 +1,41 @@
+
+#ifndef BOOST_MPL_SET_AUX_INSERT_RANGE_IMPL_HPP_INCLUDED
+#define BOOST_MPL_SET_AUX_INSERT_RANGE_IMPL_HPP_INCLUDED
+
+// Copyright Bruno Dutra 2015
+//
+// Distributed under the Boost Software License, Version 1.0. 
+// (See accompanying file LICENSE_1_0.txt or copy at 
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/mpl for documentation.
+
+// $Id$
+// $Date$
+// $Revision$
+
+#include <boost/mpl/insert_range_fwd.hpp>
+#include <boost/mpl/set/aux_/tag.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/fold.hpp>
+#include <boost/mpl/insert.hpp>
+
+namespace boost { namespace mpl {
+
+template<>
+struct insert_range_impl< aux::set_tag >
+{
+    template<
+          typename Sequence
+        , typename /*Pos*/
+        , typename Range
+        >
+    struct apply
+        : fold<Range, Sequence, insert<_1, _2> >
+    {
+    };
+};
+
+}}
+
+#endif // BOOST_MPL_SET_AUX_INSERT_RANGE_IMPL_HPP_INCLUDED

--- a/include/boost/mpl/set/set0.hpp
+++ b/include/boost/mpl/set/set0.hpp
@@ -21,6 +21,7 @@
 #include <boost/mpl/set/aux_/size_impl.hpp>
 #include <boost/mpl/set/aux_/empty_impl.hpp>
 #include <boost/mpl/set/aux_/insert_impl.hpp>
+#include <boost/mpl/set/aux_/insert_range_impl.hpp>
 #include <boost/mpl/set/aux_/erase_impl.hpp>
 #include <boost/mpl/set/aux_/erase_key_impl.hpp>
 #include <boost/mpl/set/aux_/has_key_impl.hpp>

--- a/test/insert_range.cpp
+++ b/test/insert_range.cpp
@@ -15,9 +15,17 @@
 #include <boost/mpl/find.hpp>
 #include <boost/mpl/vector_c.hpp>
 #include <boost/mpl/list.hpp>
+#include <boost/mpl/set.hpp>
+#include <boost/mpl/set_c.hpp>
+#include <boost/mpl/map.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/range_c.hpp>
 #include <boost/mpl/equal.hpp>
+#include <boost/mpl/fold.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/logical.hpp>
+#include <boost/mpl/contains.hpp>
+#include <boost/mpl/joint_view.hpp>
 
 #include <boost/mpl/aux_/test.hpp>
 
@@ -32,4 +40,34 @@ MPL_TEST_CASE()
 
     typedef insert_range< list0<>,end< list0<> >::type,list1<int> >::type result2;
     MPL_ASSERT_RELATION( size<result2>::value, ==, 1 );
+}
+
+template<typename A, typename B>
+void test_associative()
+{
+    typedef typename insert_range< A,typename end< A >::type,B >::type C;
+
+    MPL_ASSERT_RELATION( size<C>::value, <=, (size<A>::value + size<B>::value) );
+    MPL_ASSERT(( fold< joint_view< A,B >,true_,and_< _1,contains< C,_2 > > > ));
+}
+
+MPL_TEST_CASE()
+{
+    typedef set3< short,int,long > signed_integers;
+    typedef set3< unsigned short,unsigned int,unsigned long > unsigned_integers;
+    test_associative<signed_integers, unsigned_integers>();
+
+    typedef set_c< int,1,3,5,7,9 > odds;
+    typedef set_c< int,0,2,4,6,8 > evens;
+    test_associative<odds, evens>();
+
+    typedef map2<
+              pair< void,void* >
+            , pair< int,int* >
+            > pointers;
+    typedef map2<
+              pair< void const,void const* >
+            , pair< int const,int const* >
+            > pointers_to_const;
+    test_associative<pointers, pointers_to_const>();
 }


### PR DESCRIPTION
According to reference, insert_range should work for any Extensible
sequence or Extensible Associative sequence, but the default
implementation of insert_range_impl assumes a front_inserter is defined
for the given sequence, but neither Extensible nor every Extensible
Associative sequences are required to also be a Front Extensible
sequence. This fix rely only on insert, which is defined for every
Extensible sequence.