### PR TITLE
Fix to Tickets #7975 and #8749 - Branched off from develop

### DIFF
--- a/include/boost/mpl/empty_sequence.hpp
+++ b/include/boost/mpl/empty_sequence.hpp
@@ -23,7 +23,8 @@ namespace boost { namespace mpl {
 
 struct empty_sequence
 {
-    struct tag; 
+    struct tag;
+    typedef empty_sequence type;
     struct begin { typedef random_access_iterator_tag category; };    
     typedef begin end;
 };

--- a/include/boost/mpl/map/aux_/item.hpp
+++ b/include/boost/mpl/map/aux_/item.hpp
@@ -40,6 +40,7 @@ struct m_item
     typedef Key         key_;
     typedef pair<Key,T> item;
     typedef Base        base;
+    typedef m_item      type;
     
     typedef typename next< typename Base::size >::type  size;
     typedef typename next< typename Base::order >::type order;
@@ -62,6 +63,7 @@ struct m_mask
 {
     typedef void_   key_;
     typedef Base    base;
+    typedef m_mask  type;
 
     typedef typename prior< typename Base::size >::type  size;
     typedef typename x_order_impl<Base,Key>::type key_order_;
@@ -123,6 +125,7 @@ struct m_mask
 {
     typedef void_   key_;
     typedef Base    base;
+    typedef m_mask  type;
 
     typedef typename prior< typename Base::size >::type  size;
     typedef typename x_order_impl<Base,Key>::type key_order_;

--- a/include/boost/mpl/set/aux_/item.hpp
+++ b/include/boost/mpl/set/aux_/item.hpp
@@ -33,6 +33,7 @@ struct s_item
     typedef void_       last_masked_;
     typedef T           item_type_;
     typedef typename Base::item_ base;
+    typedef s_item type;
     
     typedef typename next< typename Base::size >::type  size;
     typedef typename next< typename Base::order >::type order;
@@ -57,6 +58,7 @@ struct s_mask
     typedef void_   item_type_;
     typedef typename Base::item_ base;
     typedef typename prior< typename Base::size >::type  size;
+    typedef s_mask type;
 
     BOOST_MPL_AUX_SET_OVERLOAD( aux::yes_tag, IS_MASKED, s_mask, aux::type_wrapper<T>* );
 };

--- a/test/empty_sequence.cpp
+++ b/test/empty_sequence.cpp
@@ -17,6 +17,7 @@
 #include <boost/mpl/distance.hpp>
 #include <boost/mpl/advance.hpp>
 #include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/equal.hpp>
 #include <boost/mpl/aux_/test.hpp>
 
 #include <boost/type_traits/is_same.hpp>
@@ -33,4 +34,6 @@ MPL_TEST_CASE()
 
     typedef advance_c<begin,0>::type advanced;
     MPL_ASSERT(( is_same<advanced,end> ));
+
+    MPL_ASSERT(( equal< empty_sequence, empty_sequence::type > ));
 }

--- a/test/filter_view.cpp
+++ b/test/filter_view.cpp
@@ -18,6 +18,7 @@
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/sizeof.hpp>
 #include <boost/mpl/deref.hpp>
+#include <boost/mpl/equal.hpp>
 #include <boost/mpl/aux_/test.hpp>
 
 #include <boost/type_traits/is_float.hpp>
@@ -26,6 +27,10 @@
 MPL_TEST_CASE()
 {
     typedef mpl::list<int,float,long,float,char[50],long double,char> types;
+    typedef mpl::list<float,float,long double> floats;
+
+    MPL_ASSERT(( equal< mpl::filter_view< types,boost::is_float<_> >::type,floats > ));
+
     typedef mpl::max_element<
           mpl::transform_view<
               mpl::filter_view< types,boost::is_float<_> >

--- a/test/joint_view.cpp
+++ b/test/joint_view.cpp
@@ -30,6 +30,7 @@ MPL_TEST_CASE()
     typedef range_c<int,0,15> answer;
 
     MPL_ASSERT(( equal<numbers,answer> ));
+    MPL_ASSERT(( equal<numbers::type,answer> ));
     MPL_ASSERT_RELATION( size<numbers>::value, ==, 15 );
 }
 

--- a/test/map.cpp
+++ b/test/map.cpp
@@ -217,3 +217,19 @@ MPL_TEST_CASE()
         >
     ));
 }
+
+MPL_TEST_CASE()
+{
+    typedef insert< map<>, pair<int,int> >::type little_map;
+
+    MPL_ASSERT_RELATION(size<little_map>::value, ==, 1);
+    MPL_ASSERT_RELATION(size<little_map::type>::value, ==, 1);
+}
+
+MPL_TEST_CASE()
+{
+    typedef erase_key< map< pair<float,float>, pair<int,int> >, float >::type little_map;
+
+    MPL_ASSERT_RELATION(size<little_map>::value, ==, 1);
+    MPL_ASSERT_RELATION(size<little_map::type>::value, ==, 1);
+}

--- a/test/set.cpp
+++ b/test/set.cpp
@@ -329,3 +329,19 @@ MPL_TEST_CASE()
     find_test<s>();
     find_test<s::type>();
 }
+
+MPL_TEST_CASE()
+{
+    typedef insert< set<>, int >::type little_set;
+
+    MPL_ASSERT_RELATION(size<little_set>::value, ==, 1);
+    MPL_ASSERT_RELATION(size<little_set::type>::value, ==, 1);
+}
+
+MPL_TEST_CASE()
+{
+    typedef erase_key< set< float, int >, float >::type little_set;
+
+    MPL_ASSERT_RELATION(size<little_set>::value, ==, 1);
+    MPL_ASSERT_RELATION(size<little_set::type>::value, ==, 1);
+}

--- a/test/single_view.cpp
+++ b/test/single_view.cpp
@@ -15,6 +15,7 @@
 #include <boost/mpl/advance.hpp>
 #include <boost/mpl/size.hpp>
 #include <boost/mpl/begin_end.hpp>
+#include <boost/mpl/equal.hpp>
 #include <boost/mpl/aux_/test.hpp>
 
 MPL_TEST_CASE()
@@ -37,4 +38,6 @@ MPL_TEST_CASE()
     MPL_ASSERT_RELATION( (mpl::distance<last,last>::value), ==, 0 );
 
     MPL_ASSERT_RELATION( size<view>::value, ==, 1 );
+
+    MPL_ASSERT(( equal< view, view::type > ));
 }

--- a/test/transform_view.cpp
+++ b/test/transform_view.cpp
@@ -16,12 +16,22 @@
 #include <boost/mpl/max_element.hpp>
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/sizeof.hpp>
+#include <boost/mpl/equal.hpp>
 #include <boost/mpl/aux_/test.hpp>
-
 
 MPL_TEST_CASE()
 {
     typedef list<int,long,char,char[50],double> types;
+    typedef list<
+        sizeof_<int>::type,
+        sizeof_<long>::type,
+        sizeof_<char>::type,
+        sizeof_<char[50]>::type,
+        sizeof_<double>::type
+    > sizes;
+
+    MPL_ASSERT(( equal< transform_view< types, sizeof_<_> >::type,sizes > ));
+
     typedef max_element<
           transform_view< types, sizeof_<_> >
         >::type iter;


### PR DESCRIPTION
The fix is based on the report of Ticket 8749 itself:

>I have traced the problem to the file boost/mpl/map/aux_/item.hpp in the class definition of m_item. m_item derives from Base (which is a map<...> type) but does not define a "typedef m_item type;" to act as a unary metafunction returning itself. The result is that Base::type is found instead which means that m_item acts as a unary metafunction returning a map with all the inserted elements removed. The class m_item_ at the bottom of the file properly defines a "typedef m_item_ type;" which strengthens my belief that it missing from m_item is a bug.

Originally Tickets 7975 and 8749 referred only to insertion of keys into maps, but the very same bug can be reproduced for sets as well. Moreover, the removal of keys from both also suffers of the same bug. This changes fix all these issues.