### PR TITLE
Revert "fix typo"

### DIFF
--- a/doc/src/refmanual/Iterators.rst
+++ b/doc/src/refmanual/Iterators.rst
@@ -5,7 +5,7 @@ it possible to decouple `algorithms`__ from concrete compile-time `sequence
 implementations`__. Under the hood, all MPL sequence algorithms are 
 implemented in terms of iterators. In particular, that means that they 
 will work on any custom compile-time sequence, given that the appropriate 
-iterator interface is provided.
+iterator inteface is provided.
 
 __ `Algorithms`_
 __ `label-Sequences-Classes`_
@@ -14,6 +14,6 @@ __ `label-Sequences-Classes`_
 .. More?
 
 
-.. copyright:: Copyright Â©  2001-2009 Aleksey Gurtovoy and David Abrahams
+.. copyright:: Copyright ©  2001-2009 Aleksey Gurtovoy and David Abrahams
    Distributed under the Boost Software License, Version 1.0. (See accompanying
    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Reverts boostorg/mpl#23 - shouldn't go into master