### PR TITLE
Fix "-Wc++11-extensions" warning on Clang in C++03 mode

### DIFF
--- a/include/boost/mpl/print.hpp
+++ b/include/boost/mpl/print.hpp
@@ -47,7 +47,10 @@ struct print
 #endif 
 {
 #if defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wc++11-extensions"
     const int m_x = 1 / (sizeof(T) - sizeof(T));
+# pragma clang diagnostic pop
 #elif defined(BOOST_MSVC)
     enum { n = sizeof(T) + -1 };
 #elif defined(__MWERKS__)


### PR DESCRIPTION
Including `boost/mpl/print.hpp` on Clang in C++03 mode **always** produces a warning (i.e. even without using `boost::mpl::print<T>`).

We can remove the warning by adding 
```
#pragma clang diagnostic ignored "-Wc++11-extensions"
```
Note that `-Wc++11-extensions` is not supported in Clang older than 3.0, but this is not an issue since the current `boost::mpl::print` implementation requires Clang 3.0 or newer versions and results in errors in Clang older than 3.0. 

This issue was reported by Richard Hadsell on Boost developer ML.