### PR TITLE
Remove unnecessary parenthesis gcc 8 complains about.

### DIFF
--- a/include/boost/mpl/assert.hpp
+++ b/include/boost/mpl/assert.hpp
@@ -185,14 +185,12 @@ template< typename P > struct assert_arg_pred_not
 };
 
 template< typename Pred >
-failed ************ (Pred::************ 
-      assert_arg( void (*)(Pred), typename assert_arg_pred<Pred>::type )
-    );
+failed ************ Pred::************
+      assert_arg( void (*)(Pred), typename assert_arg_pred<Pred>::type );
 
 template< typename Pred >
-failed ************ (boost::mpl::not_<Pred>::************ 
-      assert_not_arg( void (*)(Pred), typename assert_arg_pred_not<Pred>::type )
-    );
+failed ************ boost::mpl::not_<Pred>::************
+      assert_not_arg( void (*)(Pred), typename assert_arg_pred_not<Pred>::type );
 
 template< typename Pred >
 AUX778076_ASSERT_ARG(assert<false>)


### PR DESCRIPTION
Hi,

I had new warnings when migrating to gcc 8 (which are blocking for anyone using -Werror).

Cheers,
Romain