### PR TITLE
Fix BOOST_MPL_ASSERT_MSG for VC++8

### DIFF
--- a/include/boost/mpl/assert.hpp
+++ b/include/boost/mpl/assert.hpp
@@ -443,8 +443,16 @@ BOOST_MPL_AUX_ASSERT_CONSTANT( \
 /**/
 #endif
 
-#define BOOST_MPL_ASSERT_MSG( c, msg, types_ ) \
+// Work around BOOST_MPL_ASSERT_MSG_IMPL generating multiple definition linker errors on VC++8.
+#if defined(BOOST_MSVC) && BOOST_MSVC < 1500
+#   include <boost/static_assert.hpp>
+#   define BOOST_MPL_ASSERT_MSG( c, msg, types_ ) \
+BOOST_STATIC_ASSERT_MSG( c, #msg ) \
+/**/
+#else
+#   define BOOST_MPL_ASSERT_MSG( c, msg, types_ ) \
 BOOST_MPL_ASSERT_MSG_IMPL( BOOST_MPL_AUX_PP_COUNTER(), c, msg, types_ ) \
 /**/
+#endif
 
 #endif // BOOST_MPL_ASSERT_HPP_INCLUDED

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,6 +13,7 @@ compile apply_wrap.cpp ;
 compile arithmetic.cpp ;
 compile as_sequence.cpp ;
 compile assert.cpp ;
+link assert_vc8_p1.cpp assert_vc8_p2.cpp ;
 compile at.cpp ;
 compile back.cpp ;
 compile bind.cpp ;

--- a/test/assert_vc8.hpp
+++ b/test/assert_vc8.hpp
@@ -1,0 +1,28 @@
+
+// Copyright Robin Linden 2018
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/mpl for documentation.
+
+// $Id$
+// $Date$
+// $Revision$
+
+// Part of a test to demonstrate a linking error with
+// BOOST_MPL_ASSERT_MSG inside of functions under VC++8.
+
+#include <boost/mpl/assert.hpp>
+
+template<class T>
+bool func()
+{
+    BOOST_MPL_ASSERT_MSG(
+        true,
+        ALWAYS_TRUE,
+        (T));
+
+    return true;
+}

--- a/test/assert_vc8_p1.cpp
+++ b/test/assert_vc8_p1.cpp
@@ -1,0 +1,23 @@
+
+// Copyright Robin Linden 2018
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/mpl for documentation.
+
+// $Id$
+// $Date$
+// $Revision$
+
+// Part of a test to demonstrate a linking error with
+// BOOST_MPL_ASSERT_MSG inside of functions under VC++8.
+
+#include "assert_vc8.hpp"
+
+static bool a = func<int>();
+
+int main()
+{
+}

--- a/test/assert_vc8_p2.cpp
+++ b/test/assert_vc8_p2.cpp
@@ -1,0 +1,19 @@
+
+// Copyright Robin Linden 2018
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/mpl for documentation.
+
+// $Id$
+// $Date$
+// $Revision$
+
+// Part of a test to demonstrate a linking error with
+// BOOST_MPL_ASSERT_MSG inside of functions under VC++8.
+
+#include "assert_vc8.hpp"
+
+static bool a = func<int>();


### PR DESCRIPTION
The struct member function inside BOOST_MPL_ASSERT_MSG_IMPL was causing
multiple definitions of the same symbol when used inside e.g. template
functions.

An example of where this is a big issue is in the boost/geometry library
where you currently only can call each function once for each geometry
or you get hit by the multiple definitions linking error.

This fix* works around the issue by gracefully degrading to
BOOST_STATIC_ASSERT_MSG instead of failing during linking.