### PR TITLE
Add minimal cmake file 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+project(boost-mpl)
+
+add_library(boost_mpl INTERFACE)
+add_library(Boost::mpl ALIAS boost_mpl)
+
+target_include_directories(boost_mpl INTERFACE include)
+
+target_link_libraries(boost_mpl
+	INTERFACE
+		Boost::config
+		Boost::core
+		Boost::predef
+		Boost::preprocessor
+		Boost::static_assert
+		Boost::type_traits
+		Boost::utility
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,26 @@
-cmake_minimum_required(VERSION 3.5)
-project(boost-mpl)
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Mpl is currently experimental at best
+#       and the interface is likely to change in the future
 
-add_library(boost_mpl INTERFACE)
-add_library(Boost::mpl ALIAS boost_mpl)
+cmake_minimum_required( VERSION 3.5 )
+project( BoostMpl LANGUAGES CXX )
 
-target_include_directories(boost_mpl INTERFACE include)
+add_library( boost_mpl INTERFACE )
+add_library( Boost::mpl ALIAS boost_mpl )
 
-target_link_libraries(boost_mpl
-	INTERFACE
-		Boost::config
-		Boost::core
-		Boost::predef
-		Boost::preprocessor
-		Boost::static_assert
-		Boost::type_traits
-		Boost::utility
+target_include_directories( boost_mpl INTERFACE include )
+
+target_link_libraries( boost_mpl
+    INTERFACE
+        Boost::config
+        Boost::core
+        Boost::predef
+        Boost::preprocessor
+        Boost::static_assert
+        Boost::type_traits
+        Boost::utility
 )
 


### PR DESCRIPTION
This cmake file just provides the minimal infrastructure necessary, such that other libraries can get a sensible result from calling

    add_subdirectory( <path-to-boost_mpl> )
    target_link_libraries( <my_lib> PUBLIC Boost::mpl )

More information:

- https://groups.google.com/forum/#!topic/boost-developers-archive/kM4JRmyVl3M%5B1-25%5D
- https://groups.google.com/d/msg/boost-developers-archive/4HU-RzReL7U/FS1X6OFrEQAJ
- https://groups.google.com/forum/#!topic/boost-developers-archive/9ZdrVbAn1aU

Of course the file can be extended to e.g. build and run tests and support installation, but that is out of scope for this particular PR.

Note: I haven't yet hooked up the tests to travis for two reasons:

1) frankly, the travis file looks much more complicated than what I'm used to so I'm not sure how to best integrate it here. Any pointers are welcomed
2) One of the transitive dependencies (container_hash) doesn't have a cmake file yet (although https://github.com/boostorg/container_hash/pull/5 changes that). So the test would fail anyway.

