### PR TITLE
Fix unused variable warning from BOOST_MPL_ASSERT_* on Clang

### DIFF
--- a/include/boost/mpl/assert.hpp
+++ b/include/boost/mpl/assert.hpp
@@ -53,10 +53,10 @@
 #endif
 
 // agurt, 10/nov/06: use enums for Borland (which cannot cope with static constants) 
-// and GCC (which issues "unused variable" warnings when static constants are used 
+// and GCC/PGI/Clang (which issues "unused variable" warnings when static constants are used 
 // at a function scope)
 #if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x610)) \
-    || (BOOST_MPL_CFG_GCC != 0) || (BOOST_MPL_CFG_GPU != 0) || defined(__PGI)
+    || (BOOST_MPL_CFG_GCC != 0) || (BOOST_MPL_CFG_GPU != 0) || defined(__PGI) || defined(__clang__)
 #   define BOOST_MPL_AUX_ASSERT_CONSTANT(T, expr) enum { expr }
 #else
 #   define BOOST_MPL_AUX_ASSERT_CONSTANT(T, expr) BOOST_STATIC_CONSTANT(T, expr)


### PR DESCRIPTION
Fixes #41