### PR TITLE
It normally should not be necessary to use the _Z form of the BOOST_P…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ environment:
       B2_ADDRESS_MODEL: address-model=64,32
 
     - FLAVOR: Visual Studio 2010, 2012, 2013
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       TOOLSET: msvc-10.0,msvc-11.0,msvc-12.0
 
     - FLAVOR: cygwin (32-bit)
@@ -104,7 +104,7 @@ environment:
       ARCH: x86_64
       B2_ADDRESS_MODEL: address-model=64
       CXXSTD: 11,17
-      DEFINES: define=__USE_ISOC99
+      B2_DEFINES: define=__USE_ISOC99
       SCRIPT: ci\appveyor\mingw.bat
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,19 @@ environment:
     B2_VARIANT: variant=release,debug
 
   matrix:
+    - FLAVOR: Visual Studio 2019 All Modes
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      TOOLSET: msvc-14.2
+      B2_ADDRESS_MODEL: address-model=64,32
+      CXXSTD: 14,17,latest
+
+    - FLAVOR: Visual Studio 2019 New Preprocessor
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      TOOLSET: msvc-14.2
+      B2_ADDRESS_MODEL: address-model=64,32
+      CXXFLAGS: cxxflags="/Zc:preprocessor"
+      CXXSTD: 14,17,latest
+
     - FLAVOR: Visual Studio 2017 C++2a Strict
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       TOOLSET: msvc-14.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,7 @@ environment:
 
     - FLAVOR: Visual Studio 2010, 2012, 2013
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      TOOLSET: msvc-10.0,msvc-11.0,msvc-12.0
+      TOOLSET: msvc-12.0
 
     - FLAVOR: cygwin (32-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,9 +81,10 @@ environment:
       TOOLSET: msvc-14.0
       B2_ADDRESS_MODEL: address-model=64,32
 
-    - FLAVOR: Visual Studio 2010, 2012, 2013
+    - FLAVOR: Visual Studio 2012
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       TOOLSET: msvc-12.0
+      B2_ADDRESS_MODEL: address-model=64,32
 
     - FLAVOR: cygwin (32-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/include/boost/mpl/aux_/preprocessor/enum.hpp
+++ b/include/boost/mpl/aux_/preprocessor/enum.hpp
@@ -29,6 +29,10 @@
     BOOST_PP_CAT(BOOST_MPL_PP_ENUM_,n)(param) \
     /**/
     
+#   define BOOST_MPL_PP_ENUM_Z(z_ignored, n, param) \
+    BOOST_PP_CAT(BOOST_MPL_PP_ENUM_,n)(param) \
+    /**/
+    
 #   define BOOST_MPL_PP_ENUM_0(p)
 #   define BOOST_MPL_PP_ENUM_1(p) p
 #   define BOOST_MPL_PP_ENUM_2(p) p,p
@@ -51,6 +55,14 @@
 
 #   define BOOST_MPL_PP_ENUM(n, param) \
     BOOST_PP_REPEAT( \
+          n \
+        , BOOST_MPL_PP_AUX_ENUM_FUNC \
+        , param \
+        ) \
+    /**/
+
+#   define BOOST_MPL_PP_ENUM_Z(z, n, param) \
+    BOOST_PP_REPEAT_ ## z( \
           n \
         , BOOST_MPL_PP_AUX_ENUM_FUNC \
         , param \

--- a/include/boost/mpl/aux_/preprocessor/params.hpp
+++ b/include/boost/mpl/aux_/preprocessor/params.hpp
@@ -29,6 +29,10 @@
     BOOST_PP_CAT(BOOST_MPL_PP_PARAMS_,n)(p) \
     /**/
 
+#   define BOOST_MPL_PP_PARAMS_Z(z_ignored,n,p) \
+    BOOST_PP_CAT(BOOST_MPL_PP_PARAMS_,n)(p) \
+    /**/
+
 #   define BOOST_MPL_PP_PARAMS_0(p)
 #   define BOOST_MPL_PP_PARAMS_1(p) p##1
 #   define BOOST_MPL_PP_PARAMS_2(p) p##1,p##2
@@ -54,6 +58,14 @@
 
 #   define BOOST_MPL_PP_PARAMS(n, param) \
     BOOST_PP_REPEAT( \
+          n \
+        , BOOST_MPL_PP_AUX_PARAM_FUNC \
+        , param \
+        ) \
+    /**/
+
+#   define BOOST_MPL_PP_PARAMS_Z(z, n, param) \
+    BOOST_PP_REPEAT_ ## z( \
           n \
         , BOOST_MPL_PP_AUX_PARAM_FUNC \
         , param \

--- a/include/boost/mpl/has_xxx.hpp
+++ b/include/boost/mpl/has_xxx.hpp
@@ -334,7 +334,7 @@ struct trait \
 // correct name but different number of arguments.
 #   define BOOST_MPL_HAS_MEMBER_MULTI_SUBSTITUTE(z, n, args) \
       template< \
-          template< BOOST_PP_ENUM_PARAMS(BOOST_PP_INC(n), typename V) > class V \
+          template< BOOST_PP_ENUM_PARAMS_Z(z, BOOST_PP_INC(n), typename V) > class V \
        > \
       struct BOOST_MPL_HAS_MEMBER_INTROSPECTION_SUBSTITUTE_NAME(args, n) { \
       }; \
@@ -503,7 +503,7 @@ struct trait \
                  z, n, args \
              ) \
         template< \
-             template< BOOST_PP_ENUM_PARAMS(BOOST_PP_INC(n), typename U) > class U \
+             template< BOOST_PP_ENUM_PARAMS_Z(z, BOOST_PP_INC(n), typename U) > class U \
         > \
         struct BOOST_MPL_HAS_MEMBER_INTROSPECTION_SUBSTITUTE_NAME_WITH_TEMPLATE_SFINAE( \
                 args, n \

--- a/include/boost/mpl/string.hpp
+++ b/include/boost/mpl/string.hpp
@@ -500,11 +500,11 @@ namespace boost { namespace mpl
     };
 
     #define M0(z, n, data)                                                                            \
-    template<BOOST_PP_ENUM_PARAMS(BOOST_MPL_STRING_MAX_PARAMS, int C), int J>                         \
-    struct string_iterator<mpl::string<BOOST_PP_ENUM_PARAMS(BOOST_MPL_STRING_MAX_PARAMS, C)>, n, J>   \
+    template<BOOST_PP_ENUM_PARAMS_Z(z, BOOST_MPL_STRING_MAX_PARAMS, int C), int J>                    \
+    struct string_iterator<mpl::string<BOOST_PP_ENUM_PARAMS_Z(z, BOOST_MPL_STRING_MAX_PARAMS, C)>, n, J> \
     {                                                                                                 \
         enum { eomc_ = (BOOST_MPL_MULTICHAR_LENGTH(BOOST_PP_CAT(C, n)) == J + 1) };                   \
-        typedef mpl::string<BOOST_PP_ENUM_PARAMS(BOOST_MPL_STRING_MAX_PARAMS, C)> string;             \
+        typedef mpl::string<BOOST_PP_ENUM_PARAMS_Z(z, BOOST_MPL_STRING_MAX_PARAMS, C)> string;        \
         typedef std::bidirectional_iterator_tag category;                                             \
         typedef                                                                                       \
             mpl::string_iterator<string, n + eomc_, eomc_ ? 0 : J + 1>                                \
@@ -514,11 +514,11 @@ namespace boost { namespace mpl
         prior;                                                                                        \
         typedef mpl::char_<BOOST_MPL_MULTICHAR_AT(BOOST_PP_CAT(C, n), J)> type;                       \
     };                                                                                                \
-    template<BOOST_PP_ENUM_PARAMS(BOOST_MPL_STRING_MAX_PARAMS, int C)>                                \
-    struct string_iterator<mpl::string<BOOST_PP_ENUM_PARAMS(BOOST_MPL_STRING_MAX_PARAMS, C)>, n, 0>   \
+    template<BOOST_PP_ENUM_PARAMS_Z(z, BOOST_MPL_STRING_MAX_PARAMS, int C)>                           \
+    struct string_iterator<mpl::string<BOOST_PP_ENUM_PARAMS_Z(z, BOOST_MPL_STRING_MAX_PARAMS, C)>, n, 0> \
     {                                                                                                 \
         enum { eomc_ = (BOOST_MPL_MULTICHAR_LENGTH(BOOST_PP_CAT(C, n)) == 1) };                       \
-        typedef mpl::string<BOOST_PP_ENUM_PARAMS(BOOST_MPL_STRING_MAX_PARAMS, C)> string;             \
+        typedef mpl::string<BOOST_PP_ENUM_PARAMS_Z(z, BOOST_MPL_STRING_MAX_PARAMS, C)> string;        \
         typedef std::bidirectional_iterator_tag category;                                             \
         typedef                                                                                       \
             mpl::string_iterator<string, n + eomc_, !eomc_>                                           \

--- a/test/apply_wrap.cpp
+++ b/test/apply_wrap.cpp
@@ -24,14 +24,14 @@
 #include <boost/preprocessor/cat.hpp>
 
 #if !defined(BOOST_MPL_CFG_NO_DEFAULT_PARAMETERS_IN_NESTED_TEMPLATES)
-#   define APPLY_0_FUNC_DEF(i) \
+#   define APPLY_0_FUNC_DEF(z_ignored,i) \
     struct f0 \
     { \
         template< typename T = int > struct apply { typedef char type; }; \
     }; \
 /**/
 #else
-#   define APPLY_0_FUNC_DEF(i) \
+#   define APPLY_0_FUNC_DEF(z_ignored,i) \
     struct f0 \
     { \
         template< typename T > struct apply { typedef char type; }; \
@@ -39,16 +39,16 @@
 /**/
 #endif
 
-#define APPLY_N_FUNC_DEF(i) \
+#define APPLY_N_FUNC_DEF(z,i) \
     struct first##i \
     { \
-        template< BOOST_MPL_PP_PARAMS(i, typename U) > \
+        template< BOOST_MPL_PP_PARAMS_Z(z, i, typename U) > \
         struct apply { typedef U1 type; }; \
     }; \
     \
     struct last##i \
     { \
-        template< BOOST_MPL_PP_PARAMS(i, typename U) > \
+        template< BOOST_MPL_PP_PARAMS_Z(z, i, typename U) > \
         struct apply { typedef BOOST_PP_CAT(U,i) type; }; \
     }; \
 /**/
@@ -58,7 +58,7 @@
           i \
         , APPLY_N_FUNC_DEF \
         , APPLY_0_FUNC_DEF \
-        )(i) \
+        )(z,i) \
 /**/
 
 namespace { namespace test {
@@ -73,22 +73,22 @@ struct g0 { struct apply { typedef char type; }; };
 
 }}
 
-#define APPLY_0_TEST(i, apply_) \
+#define APPLY_0_TEST(z_ignored, i, apply_) \
     typedef apply_<test::f##i>::type t; \
     { MPL_ASSERT(( boost::is_same<t, char> )); } \
 /**/
 
-#define APPLY_N_TEST(i, apply_) \
+#define APPLY_N_TEST(z, i, apply_) \
     typedef apply_< \
           test::first##i \
         , char \
         BOOST_PP_COMMA_IF(BOOST_PP_DEC(i)) \
-        BOOST_MPL_PP_ENUM(BOOST_PP_DEC(i), int) \
+        BOOST_MPL_PP_ENUM_Z(z, BOOST_PP_DEC(i), int) \
         >::type t1##i; \
     \
     typedef apply_< \
           test::last##i \
-        , BOOST_MPL_PP_ENUM(BOOST_PP_DEC(i), int) \
+        , BOOST_MPL_PP_ENUM_Z(z, BOOST_PP_DEC(i), int) \
         BOOST_PP_COMMA_IF(BOOST_PP_DEC(i)) char \
         >::type t2##i; \
     { MPL_ASSERT(( boost::is_same<t1##i, char> )); } \
@@ -100,7 +100,7 @@ struct g0 { struct apply { typedef char type; }; };
           i \
         , APPLY_N_TEST \
         , APPLY_0_TEST \
-        )(i, BOOST_PP_CAT(apply_wrap,i)) \
+        )(z, i, BOOST_PP_CAT(apply_wrap,i)) \
 /**/
 
 

--- a/test/aux_/increased_arity.cpp
+++ b/test/aux_/increased_arity.cpp
@@ -25,11 +25,11 @@
 #include <boost/preprocessor/enum_params.hpp>
 #include <boost/preprocessor/facilities/intercept.hpp>
 
-#define TEST_N_ARY(unused1, N, unused2) \
+#define TEST_N_ARY(z, N, unused2) \
     static_assert_< \
         apply< \
-            and_<BOOST_PP_ENUM_PARAMS(N, _ BOOST_PP_INTERCEPT)>, \
-            BOOST_PP_ENUM_PARAMS(N, true_ BOOST_PP_INTERCEPT) \
+            and_<BOOST_PP_ENUM_PARAMS_Z(z, N, _ BOOST_PP_INTERCEPT)>, \
+            BOOST_PP_ENUM_PARAMS_Z(z, N, true_ BOOST_PP_INTERCEPT) \
         > \
     >(); \
 /**/


### PR DESCRIPTION
…P_ENUM macro, although it is perfectly legal and helpful to do so, but in this case it is necessary as a workaround for a bug in the new VC++ standard conforming preprocessor. The bug manifests itself when testing the TTI library, which internally uses the Boost MPL code. The bug in the new VC++ standard conforming compiler is fixed in the VS2019 preview product, so that fix is sure to find its way to the official VS2019 product sometime soon. In the meantime this "fix" shortens the macro expansion somewhat and, while it should not be necessary, is still helpful.

See https://github.com/boostorg/preprocessor/issues/33 for a report and response to the VC++ new preprocessor bug.