### PR TITLE
Fix some -Wsign-conversion warnings

### DIFF
--- a/include/boost/mpl/aux_/preprocessed/gcc/template_arity.hpp
+++ b/include/boost/mpl/aux_/preprocessed/gcc/template_arity.hpp
@@ -12,7 +12,7 @@
 namespace boost { namespace mpl { namespace aux {
 template< int N > struct arity_tag
 {
-    typedef char (&type)[N + 1];
+    typedef char (&type)[(unsigned)N + 1];
 };
 
 template<

--- a/include/boost/mpl/aux_/template_arity.hpp
+++ b/include/boost/mpl/aux_/template_arity.hpp
@@ -65,7 +65,7 @@ namespace boost { namespace mpl { namespace aux {
 
 template< BOOST_MPL_AUX_NTTP_DECL(int, N) > struct arity_tag
 {
-    typedef char (&type)[N + 1];
+    typedef char (&type)[(unsigned)N + 1];
 };
 
 #   define AUX778076_MAX_ARITY_OP(unused, state, i_) \

--- a/include/boost/mpl/aux_/yes_no.hpp
+++ b/include/boost/mpl/aux_/yes_no.hpp
@@ -18,6 +18,7 @@
 #include <boost/mpl/aux_/config/arrays.hpp>
 #include <boost/mpl/aux_/config/msvc.hpp>
 #include <boost/mpl/aux_/config/workaround.hpp>
+#include <cstddef>
 
 
 namespace boost { namespace mpl { namespace aux {
@@ -36,7 +37,7 @@ template<> struct yes_no_tag<true>
 };
 
 
-template< BOOST_MPL_AUX_NTTP_DECL(long, n) > struct weighted_tag
+template< BOOST_MPL_AUX_NTTP_DECL(std::size_t, n) > struct weighted_tag
 {
 #if !BOOST_WORKAROUND(BOOST_MSVC, < 1300)
     typedef char (&type)[n];


### PR DESCRIPTION
Detect while using boost::transform_iterator in a Boost.Container test