### PR TITLE
refactor: use core/ref.hpp over ref.hpp

### DIFF
--- a/include/boost/mpl/aux_/unwrap.hpp
+++ b/include/boost/mpl/aux_/unwrap.hpp
@@ -15,7 +15,7 @@
 // $Date$
 // $Revision$
 
-#include <boost/ref.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/mpl/aux_/config/gpu.hpp>
 
 namespace boost { namespace mpl { namespace aux {


### PR DESCRIPTION
The later is deprecated.