### PR TITLE
Unify macro variable naming

### DIFF
--- a/include/boost/mpl/list.hpp
+++ b/include/boost/mpl/list.hpp
@@ -24,17 +24,17 @@
 #   include <boost/preprocessor/stringize.hpp>
 
 #if !defined(BOOST_NEEDS_TOKEN_PASTING_OP_FOR_TOKENS_JUXTAPOSING)
-#   define AUX778076_LIST_HEADER \
+#   define AUX778076_HEADER \
     BOOST_PP_CAT(list,BOOST_MPL_LIMIT_LIST_SIZE).hpp \
     /**/
 #else
-#   define AUX778076_LIST_HEADER \
+#   define AUX778076_HEADER \
     BOOST_PP_CAT(list,BOOST_MPL_LIMIT_LIST_SIZE)##.hpp \
     /**/
 #endif
 
-#   include BOOST_PP_STRINGIZE(boost/mpl/list/AUX778076_LIST_HEADER)
-#   undef AUX778076_LIST_HEADER
+#   include BOOST_PP_STRINGIZE(boost/mpl/list/AUX778076_HEADER)
+#   undef AUX778076_HEADER
 #endif
 
 #include <boost/mpl/aux_/config/use_preprocessed.hpp>


### PR DESCRIPTION
In order to simplify automated dependency analysis, I would like to unify macro naming used in boost/mpl.

This is just the first part of the changeset.
I will submit other changes if this one will turn out to be acceptable.