### PR TITLE
Use static const for next/prior from C++11

### DIFF
--- a/include/boost/mpl/aux_/integral_wrapper.hpp
+++ b/include/boost/mpl/aux_/integral_wrapper.hpp
@@ -56,7 +56,8 @@ struct AUX_WRAPPER_NAME
 // have to #ifdef here: some compilers don't like the 'N + 1' form (MSVC),
 // while some other don't like 'value + 1' (Borland), and some don't like
 // either
-#if BOOST_WORKAROUND(__EDG_VERSION__, <= 243)
+#if BOOST_WORKAROUND(__EDG_VERSION__, <= 243) \
+    || __cplusplus >= 201703L
  private:
     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, next_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N + 1)));
     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, prior_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N - 1)));

--- a/include/boost/mpl/aux_/integral_wrapper.hpp
+++ b/include/boost/mpl/aux_/integral_wrapper.hpp
@@ -57,7 +57,7 @@ struct AUX_WRAPPER_NAME
 // while some other don't like 'value + 1' (Borland), and some don't like
 // either
 #if BOOST_WORKAROUND(__EDG_VERSION__, <= 243) \
-    || __cplusplus >= 201703L
+    || __cplusplus >= 201103L
  private:
     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, next_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N + 1)));
     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, prior_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N - 1)));


### PR DESCRIPTION
Trying to form next/prior in constant evaluation may be ill-formed. Fixes #69.