### PR TITLE
Do not check the bitand/bitor macros in cplusplus mode

### DIFF
--- a/include/boost/mpl/and.hpp
+++ b/include/boost/mpl/and.hpp
@@ -28,7 +28,7 @@
 // 'or' and 'and' macros, see http://tinyurl.com/3et69; 'defined(and)'
 // has to be checked in a separate condition, otherwise GCC complains 
 // about 'and' being an alternative token
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__cplusplus)
 #ifndef __GCCXML__
 #if defined(and) 
 #   pragma push_macro("and")
@@ -41,7 +41,7 @@
 #   define BOOST_MPL_PREPROCESSED_HEADER and.hpp
 #   include <boost/mpl/aux_/include_preprocessed.hpp>
 
-#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__cplusplus)
 #ifndef __GCCXML__
 #if defined(and) 
 #   pragma pop_macro("and")

--- a/include/boost/mpl/bitand.hpp
+++ b/include/boost/mpl/bitand.hpp
@@ -19,7 +19,7 @@
 // macros, see http://tinyurl.com/ycwdxco; 'defined(bitand)'
 // has to be checked in a separate condition, otherwise GCC complains 
 // about 'bitand' being an alternative token
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__cplusplus)
 #ifndef __GCCXML__
 #if defined(bitand)
 #   pragma push_macro("bitand")
@@ -34,7 +34,7 @@
 #define AUX778076_OP_TOKEN  &
 #include <boost/mpl/aux_/arithmetic_op.hpp>
 
-#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__cplusplus)
 #ifndef __GCCXML__
 #if defined(bitand)
 #   pragma pop_macro("bitand")

--- a/include/boost/mpl/bitor.hpp
+++ b/include/boost/mpl/bitor.hpp
@@ -19,7 +19,7 @@
 // macros, see http://tinyurl.com/ycwdxco; 'defined(bitor)'
 // has to be checked in a separate condition, otherwise GCC complains 
 // about 'bitor' being an alternative token
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__cplusplus)
 #ifndef __GCCXML__
 #if defined(bitor)
 #   pragma push_macro("bitor")
@@ -34,7 +34,7 @@
 #define AUX778076_OP_TOKEN  |
 #include <boost/mpl/aux_/arithmetic_op.hpp>
 
-#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__cplusplus)
 #ifndef __GCCXML__
 #if defined(bitor)
 #   pragma pop_macro("bitor")

--- a/include/boost/mpl/or.hpp
+++ b/include/boost/mpl/or.hpp
@@ -29,7 +29,7 @@
 // 'or' and 'and' macros, see http://tinyurl.com/3et69; 'defined(or)'
 // has to be checked in a separate condition, otherwise GCC complains 
 // about 'or' being an alternative token
-#if defined(_MSC_VER)
+#if defined(_MSC_VER)&& !defined(__cplusplus)
 #ifndef __GCCXML__
 #if defined(or)
 #   pragma push_macro("or")
@@ -42,7 +42,7 @@
 #   define BOOST_MPL_PREPROCESSED_HEADER or.hpp
 #   include <boost/mpl/aux_/include_preprocessed.hpp>
 
-#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__cplusplus)
 #ifndef __GCCXML__
 #if defined(or)
 #   pragma pop_macro("or")


### PR DESCRIPTION
Some 3rdparty parsers (e.g. Qt moc) fail to parse the bitand.hpp due to the fact that bitand is a keyword in C++, not a macro. Modern MSVC versions define bitand/bitor only if __cplusplus macro is not defined, see iso646.h: https://pastebin.com/zTcd0juT

Thus, boost can also check the macro only in C mode making moc happy