### PR TITLE
Fix preprocessed python3 scripts

### DIFF
--- a/preprocessed/README.txt
+++ b/preprocessed/README.txt
@@ -5,12 +5,12 @@ Pre-processing of MPL-containers can be accomplished using the script
 "boost_mpl_preprocess.py". In the simple case call it with a single
 argument which is the path to the source-directory of Boost.
 
-  python boost_mpl_preprocess.py <path-to-boost-sourcedir>
+  python3 boost_mpl_preprocess.py <path-to-boost-sourcedir>
 
 If the Boost source-directory is the one this script resides in, you
 can just call it without any arguments.
 
-  python boost_mpl_preprocess.py
+  python3 boost_mpl_preprocess.py
 
 Either way, this will pre-process all four MPL-container types (vector,
 list, set, map) and makes them able to hold up to 100 elements. They can
@@ -22,7 +22,7 @@ be different from the one of other MPL-container types and it can also
 differ between its 'numbered' and 'variadic' form.
 To see all options, call the script like this:
 
-  python boost_mpl_preprocess.py --help
+  python3 boost_mpl_preprocess.py --help
 
 
 Fixing pre-processing of MPL-containers
@@ -44,12 +44,12 @@ can also fix them explicitly by calling "fix_boost_mpl_preprocess.py"
 directly.
 If you just want to test if any fixing is needed call it like this:
 
-  python fix_boost_mpl_preprocess.py --check-only <path-to-boost-sourcedir>
+  python3 fix_boost_mpl_preprocess.py --check-only <path-to-boost-sourcedir>
 
 This will tell you if any fixing is needed. In such a case call the script
 "fix_boost_mpl_preprocess.py" like this:
 
-  python fix_boost_mpl_preprocess.py <path-to-boost-sourcedir>
+  python3 fix_boost_mpl_preprocess.py <path-to-boost-sourcedir>
 
 This will fix the header-comments of all the source-files needed during
 pre-processing. Calling "boost_mpl_preprocess.py" afterwards should then

--- a/preprocessed/boost_mpl_preprocess.py
+++ b/preprocessed/boost_mpl_preprocess.py
@@ -29,7 +29,7 @@ def create_more_container_files(sourceDir, suffix, maxElements, containers, cont
             newFile = os.path.join( sourceDir, container, container + str(i+10) + suffix )
             shutil.copyfile( os.path.join( sourceDir, container, container + "20" + suffix ), newFile ) 
             # Adjust copy of "template"-file accordingly.
-            for line in fileinput.input( newFile, inplace=1, mode="rU" ):
+            for line in fileinput.input( newFile, inplace=1, mode="r" ):
                 line = re.sub(r'20', '%TWENTY%', line.rstrip())
                 line = re.sub(r'11', '%ELEVEN%', line.rstrip())
                 line = re.sub(r'10(?![0-9])', '%TEN%', line.rstrip())
@@ -43,7 +43,7 @@ def create_more_container_files(sourceDir, suffix, maxElements, containers, cont
             newFile = os.path.join( sourceDir, container, container + str(i+10) + "_c" + suffix )
             shutil.copyfile( os.path.join( sourceDir, container, container + "20_c" + suffix ), newFile ) 
             # Adjust copy of "template"-file accordingly.
-            for line in fileinput.input( newFile, inplace=1, mode="rU" ):
+            for line in fileinput.input( newFile, inplace=1, mode="r" ):
                 line = re.sub(r'20', '%TWENTY%', line.rstrip())
                 line = re.sub(r'11', '%ELEVEN%', line.rstrip())
                 line = re.sub(r'10(?![0-9])', '%TEN%', line.rstrip())
@@ -73,7 +73,7 @@ def adjust_container_limits_for_variadic_sequences(headerDir, containers, maxEle
         headerFile = os.path.join( headerDir, "limits", container + ".hpp" )
         regexMatch   = r'(define\s+BOOST_MPL_LIMIT_' + container.upper() + r'_SIZE\s+)[0-9]+'
         regexReplace = r'\g<1>' + re.escape( str(maxElements) )
-        for line in fileinput.input( headerFile, inplace=1, mode="rU" ):
+        for line in fileinput.input( headerFile, inplace=1, mode="r" ):
             line = re.sub(regexMatch, regexReplace, line.rstrip())
             print(line)
 

--- a/preprocessed/fix_boost_mpl_preprocess.py
+++ b/preprocessed/fix_boost_mpl_preprocess.py
@@ -21,7 +21,7 @@ def check_header_comment(filename):
     # Check input file.
     name = os.path.basename( filename )
     # Read content of input file.
-    sourcefile = open( filename, "rU" )
+    sourcefile = open( filename, "r" )
     content = sourcefile.read()
     sourcefile.close()
     # Search content for '$Id$'.
@@ -93,7 +93,7 @@ def fix_header_comment(filename, timestamp):
     """Fixes the header-comment of the given file."""
     # Fix input file.
     name = os.path.basename( filename )
-    for line in fileinput.input( filename, inplace=1, mode="rU" ):
+    for line in fileinput.input( filename, inplace=1, mode="r" ):
         # If header-comment already contains anything for '$Id$', remove it.
         line = re.sub(r'\$Id:[^$]+\$', r'$Id$', line.rstrip())
         # Replace '$Id$' by a string containing the file's name (and a timestamp)!


### PR DESCRIPTION
https://github.com/boostorg/mpl/pull/68 was incomplete; I finished this for modern python3 and checked that the script can run.  The only incompatible issue was that files were opened with "rU" and the "U" is no longer valid.  I updated the README, but I did not regenerate the files.  When I did, it wouldn't build in CI.

This fixes #67 